### PR TITLE
Add ruby3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - "2.3.7"
   - "2.4.4"
   - "2.5.1"
+  - "2.7.2"
 before_install:
   - gem install bundler
 script: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: ruby
 rvm:
-  - "2.0.0"
-  - "2.1.10"
-  - "2.2.10"
-  - "2.3.7"
-  - "2.4.4"
-  - "2.5.1"
-  - "2.7.2"
+  - "2.6.7"
+  - "2.7.3"
+  - "3.0.1"
 before_install:
   - gem install bundler
 script: bundle exec rspec

--- a/lib/tcr/recordable_tcp_socket.rb
+++ b/lib/tcr/recordable_tcp_socket.rb
@@ -54,7 +54,8 @@ module TCR
     end
 
     def write_nonblock(str, *_rest)
-      write(str)
+      _write(:write_nonblock, str)
+      str.length
     end
 
     def ssl_version

--- a/lib/tcr/recordable_tcp_socket.rb
+++ b/lib/tcr/recordable_tcp_socket.rb
@@ -52,6 +52,17 @@ module TCR
       str.length
     end
 
+    def write_nonblock(str, *_rest)
+      write(str)
+    end
+
+    def ssl_version
+    end
+
+    def cipher
+      {}
+    end
+
     def to_io
       if live
         @socket.to_io

--- a/lib/tcr/recordable_tcp_socket.rb
+++ b/lib/tcr/recordable_tcp_socket.rb
@@ -13,6 +13,7 @@ module TCR
       @read_lock = []
       @recording = cassette.next_session
       @live = cassette.recording?
+      @config_block_for_reads = TCR.configuration.block_for_reads
 
       if live
         begin
@@ -90,6 +91,8 @@ module TCR
 
     private
 
+    attr_reader :config_block_for_reads
+
     def check_recording_for_errors
       raise Marshal.load(recording.first.last) if recording.first.first == "error"
     end
@@ -128,7 +131,7 @@ module TCR
           payload = data.dup if !data.is_a?(Symbol)
           recording << ["read", payload]
       else
-        _block_for_read_data if blocking && TCR.configuration.block_for_reads
+        _block_for_read_data if blocking && config_block_for_reads
         raise EOFError if recording.empty?
         direction, data = recording.shift
         _ensure_direction("read", direction)

--- a/spec/fixtures/multitest-extra-smtp.json
+++ b/spec/fixtures/multitest-extra-smtp.json
@@ -10,21 +10,15 @@
     ],
     [
       "read",
-      "250-relay-5.us-east-1.relay-prod\r\n250-PIPELINING\r\n250-SIZE 26214400\r\n250-STARTTLS\r\n250-AUTH PLAIN LOGIN\r\n250-ENHANCEDSTATUSCODES\r\n250 8BITMIME\r\n"
+      "250-relay-4.eu-west-1.relay-prod\r\n250-PIPELINING\r\n250-SIZE 26214400\r\n250-STARTTLS\r\n250-AUTH PLAIN LOGIN\r\n250-ENHANCEDSTATUSCODES\r\n250-8BITMIME\r\n250 CHUNKING\r\n"
     ],
     [
       "write",
-      "QUIT\r\n"
+      "STARTTLS\r\n"
     ],
     [
       "read",
-      "221 2.0.0 Bye\r\n"
-    ]
-  ],
-  [
-    [
-      "read",
-      "220 mail.smtp2go.com ESMTP Exim 4.86 Wed, 02 Mar 2016 02:55:19 +0000\r\n"
+      "220 2.0.0 Ready to start TLS\r\n"
     ],
     [
       "write",
@@ -32,15 +26,11 @@
     ],
     [
       "read",
-      "250-mail.smtp2go.com Hello localhost [50.160.254.134]\r\n250-SIZE 52428800\r\n250-8BITMIME\r\n250-DSN\r\n250-PIPELINING\r\n250-AUTH CRAM-MD5 PLAIN LOGIN\r\n250-STARTTLS\r\n250-PRDR\r\n250 HELP\r\n"
-    ],
-    [
-      "write",
-      "QUIT\r\n"
-    ],
-    [
-      "read",
-      "221 mail.smtp2go.com closing connection\r\n"
+      "250-relay-4.eu-west-1.relay-prod\r\n250-PIPELINING\r\n250-SIZE 26214400\r\n250-AUTH PLAIN LOGIN\r\n250-ENHANCEDSTATUSCODES\r\n250-8BITMIME\r\n250 CHUNKING\r\n"
     ]
+  ],
+  [
+    "read",
+    "extra"
   ]
 ]

--- a/spec/fixtures/multitest-smtp.json
+++ b/spec/fixtures/multitest-smtp.json
@@ -10,21 +10,15 @@
     ],
     [
       "read",
-      "250-relay-5.us-east-1.relay-prod\r\n250-PIPELINING\r\n250-SIZE 26214400\r\n250-STARTTLS\r\n250-AUTH PLAIN LOGIN\r\n250-ENHANCEDSTATUSCODES\r\n250 8BITMIME\r\n"
+      "250-relay-4.eu-west-1.relay-prod\r\n250-PIPELINING\r\n250-SIZE 26214400\r\n250-STARTTLS\r\n250-AUTH PLAIN LOGIN\r\n250-ENHANCEDSTATUSCODES\r\n250-8BITMIME\r\n250 CHUNKING\r\n"
     ],
     [
       "write",
-      "QUIT\r\n"
+      "STARTTLS\r\n"
     ],
     [
       "read",
-      "221 2.0.0 Bye\r\n"
-    ]
-  ],
-  [
-    [
-      "read",
-      "220 mail.smtp2go.com ESMTP Exim 4.86 Wed, 02 Mar 2016 02:55:19 +0000\r\n"
+      "220 2.0.0 Ready to start TLS\r\n"
     ],
     [
       "write",
@@ -32,15 +26,37 @@
     ],
     [
       "read",
-      "250-mail.smtp2go.com Hello localhost [50.160.254.134]\r\n250-SIZE 52428800\r\n250-8BITMIME\r\n250-DSN\r\n250-PIPELINING\r\n250-AUTH CRAM-MD5 PLAIN LOGIN\r\n250-STARTTLS\r\n250-PRDR\r\n250 HELP\r\n"
+      "250-relay-4.eu-west-1.relay-prod\r\n250-PIPELINING\r\n250-SIZE 26214400\r\n250-AUTH PLAIN LOGIN\r\n250-ENHANCEDSTATUSCODES\r\n250-8BITMIME\r\n250 CHUNKING\r\n"
+    ]
+  ],
+  [
+    [
+      "read",
+      "220 mail.smtp2go.com ESMTP Exim 4.94.2-S2G Sat, 05 Jun 2021 01:05:33 +0000\r\n"
     ],
     [
       "write",
-      "QUIT\r\n"
+      "EHLO localhost\r\n"
     ],
     [
       "read",
-      "221 mail.smtp2go.com closing connection\r\n"
+      "250-mail.smtp2go.com Hello localhost [89.153.206.215]\r\n250-SIZE 52428800\r\n250-8BITMIME\r\n250-DSN\r\n250-PIPELINING\r\n250-PIPE_CONNECT\r\n250-AUTH CRAM-MD5 PLAIN LOGIN\r\n250-CHUNKING\r\n250-STARTTLS\r\n250-PRDR\r\n250-SMTPUTF8\r\n250 HELP\r\n"
+    ],
+    [
+      "write",
+      "STARTTLS\r\n"
+    ],
+    [
+      "read",
+      "220 TLS go ahead\r\n"
+    ],
+    [
+      "write",
+      "EHLO localhost\r\n"
+    ],
+    [
+      "read",
+      "250-mail.smtp2go.com Hello localhost [89.153.206.215]\r\n250-SIZE 52428800\r\n250-8BITMIME\r\n250-DSN\r\n250-PIPELINING\r\n250-PIPE_CONNECT\r\n250-AUTH CRAM-MD5 PLAIN LOGIN\r\n250-CHUNKING\r\n250-PRDR\r\n250-SMTPUTF8\r\n250 HELP\r\n"
     ]
   ]
 ]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,7 +19,6 @@ end
 
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -26,19 +26,19 @@ RSpec.describe TCR do
 
   describe ".configuration" do
     it "has a default cassette location configured" do
-      TCR.configuration.cassette_library_dir.should == "fixtures/tcr_cassettes"
+      expect(TCR.configuration.cassette_library_dir).to eq "fixtures/tcr_cassettes"
     end
 
     it "has an empty list of hook ports by default" do
-      TCR.configuration.hook_tcp_ports.should == []
+      expect(TCR.configuration.hook_tcp_ports).to eq []
     end
 
     it "defaults to erroring on read/write mismatch access" do
-      TCR.configuration.block_for_reads.should be_falsey
+      expect(TCR.configuration.block_for_reads).to be_falsey
     end
 
     it "defaults to hit all to false" do
-      TCR.configuration.hit_all.should be_falsey
+      expect(TCR.configuration.hit_all).to be_falsey
     end
   end
 
@@ -122,7 +122,7 @@ RSpec.describe TCR do
     it "disables hooks within the block" do
       TCR.configure { |c| c.hook_tcp_ports = [2525] }
       TCR.turned_off do
-        TCR.configuration.hook_tcp_ports.should == []
+        expect(TCR.configuration.hook_tcp_ports).to eq []
       end
     end
 
@@ -225,7 +225,7 @@ RSpec.describe TCR do
           tcp_socket.close
         end
         cassette_contents = File.open("test.json") { |f| f.read }
-        cassette_contents.include?("220 smtp.mandrillapp.com ESMTP").should == true
+        expect(cassette_contents.include?("220 smtp.mandrillapp.com ESMTP")).to be_truthy
       end
     end
 
@@ -248,8 +248,8 @@ RSpec.describe TCR do
           tcp_socket.close
         end
         cassette_contents = File.open("test.yaml") { |f| f.read }
-        cassette_contents.include?("---").should == true
-        cassette_contents.include?("220 smtp.mandrillapp.com ESMTP").should == true
+        expect(cassette_contents.include?("---")).to be_truthy
+        expect(cassette_contents.include?("220 smtp.mandrillapp.com ESMTP")).to be_truthy
       end
     end
 
@@ -296,7 +296,7 @@ RSpec.describe TCR do
       TCR.use_cassette("spec/fixtures/mandrill_smtp") do
         tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
         io = Net::InternetMessageIO.new(tcp_socket)
-        line = io.readline.should include("220 smtp.mandrillapp.com ESMTP")
+        expect(io.readline).to include("220 smtp.mandrillapp.com ESMTP")
       end
     end
 
@@ -374,19 +374,19 @@ RSpec.describe TCR do
           smtp.finish
         end
         cassette_contents = File.open("test.json") { |f| f.read }
-        cassette_contents.include?("smtp.mandrillapp.com ESMTP").should == true
-        cassette_contents.include?("mail.smtp2go.com ESMTP").should == true
+        expect(cassette_contents.include?("smtp.mandrillapp.com ESMTP")).to be_truthy
+        expect(cassette_contents.include?("mail.smtp2go.com ESMTP")).to be_truthy
       end
 
       it "plays back multiple sessions per cassette in order" do
         TCR.use_cassette("spec/fixtures/multitest") do
           tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
           io = Net::InternetMessageIO.new(tcp_socket)
-          line = io.readline.should include("smtp.mandrillapp.com ESMTP")
+          expect(io.readline).to include("smtp.mandrillapp.com ESMTP")
 
           tcp_socket = TCPSocket.open("mail.smtp2go.com", 2525)
           io = Net::InternetMessageIO.new(tcp_socket)
-          line = io.readline.should include("mail.smtp2go.com ESMTP")
+          expect(io.readline).to include("mail.smtp2go.com ESMTP")
         end
       end
 
@@ -471,7 +471,7 @@ RSpec.describe TCR do
       c.cassette_library_dir = "."
     }
 
-    TCR.use_cassette("test") do
+    TCR.use_cassette("spec/fixtures/starwars_telnet") do
       sock = Socket.tcp("towel.blinkenlights.nl", 23)
       expect(sock).to be_a(TCR::RecordableTCPSocket)
     end

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -515,4 +515,26 @@ RSpec.describe TCR do
       end
     }.not_to raise_error
   end
+
+  context 'Ractor' do
+    before do
+      TCR.configure { |c|
+        c.hook_tcp_ports = [23]
+        c.cassette_library_dir = "."
+      }
+    end
+
+    it 'should be available in Ractors' do
+      next unless defined?(Ractor)
+
+      TCR.use_cassette("spec/fixtures/starwars_telnet") do
+        sock = Socket.tcp("towel.blinkenlights.nl", 23)
+        expect do
+          Ractor.new(sock) do |sock|
+            #noop
+          end
+        end.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
Removed EOL Ruby versions and added actual instead
Keep in mind, that the most recent versions require TLS in SMTP requests, which required to update a couple of requests.
Made specs green again

Added Ruby 3 Ractor support (technically lib/tcr/recordable_tcp_socket.rb#13 was the only thing which i initially needed)
