### PR TITLE
Add newer ruby versions to CI

### DIFF
--- a/.github/workflows/tcr.yml
+++ b/.github/workflows/tcr.yml
@@ -21,6 +21,7 @@ jobs:
           - "2.5.1"
           - "2.7.3"
           - "3.0.1"
+          - "3.1.4"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tcr.yml
+++ b/.github/workflows/tcr.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.ruby == '2.2.10' && 'ubuntu-20.04' || 'ubuntu-latest' }}
 
     strategy:
       matrix:
@@ -38,7 +38,7 @@ jobs:
 
   testall:
     if: ${{ always() }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.ruby == '2.2.10' && 'ubuntu-20.04' || 'ubuntu-latest' }}
     name: Test (matrix)
     needs: [test]
     steps:

--- a/.github/workflows/tcr.yml
+++ b/.github/workflows/tcr.yml
@@ -22,6 +22,7 @@ jobs:
           - "2.7.3"
           - "3.0.1"
           - "3.1.4"
+          - "3.2.2"
 
     steps:
       - uses: actions/checkout@v2

--- a/lib/tcr/cassette.rb
+++ b/lib/tcr/cassette.rb
@@ -16,7 +16,7 @@ module TCR
     end
 
     def recording?
-      @recording ||= !File.exists?(filename)
+      @recording ||= !File.exist?(filename)
     end
 
     def next_session

--- a/spec/tcr_spec.rb
+++ b/spec/tcr_spec.rb
@@ -15,13 +15,13 @@ RSpec.describe TCR do
   end
 
   around(:each) do |example|
-    File.unlink("test.json") if File.exists?("test.json")
-    File.unlink("test.yaml") if File.exists?("test.yaml")
-    File.unlink("test.marshal") if File.exists?("test.marshal")
+    File.unlink("test.json") if File.exist?("test.json")
+    File.unlink("test.yaml") if File.exist?("test.yaml")
+    File.unlink("test.marshal") if File.exist?("test.marshal")
     example.run
-    File.unlink("test.json") if File.exists?("test.json")
-    File.unlink("test.yaml") if File.exists?("test.yaml")
-    File.unlink("test.marshal") if File.exists?("test.marshal")
+    File.unlink("test.json") if File.exist?("test.json")
+    File.unlink("test.yaml") if File.exist?("test.yaml")
+    File.unlink("test.marshal") if File.exist?("test.marshal")
   end
 
   describe ".configuration" do
@@ -214,7 +214,7 @@ RSpec.describe TCR do
           TCR.use_cassette("test") do
             tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
           end
-        }.to change{ File.exists?("./test.json") }.from(false).to(true)
+        }.to change{ File.exist?("./test.json") }.from(false).to(true)
       end
 
       it "records the tcp session data into the file" do
@@ -237,7 +237,7 @@ RSpec.describe TCR do
           TCR.use_cassette("test") do
             tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
           end
-        }.to change{ File.exists?("./test.yaml") }.from(false).to(true)
+        }.to change{ File.exist?("./test.yaml") }.from(false).to(true)
       end
 
       it "records the tcp session data into the yaml file" do
@@ -261,7 +261,7 @@ RSpec.describe TCR do
           TCR.use_cassette("test") do
             tcp_socket = TCPSocket.open("smtp.mandrillapp.com", 2525)
           end
-        }.to change{ File.exists?("./test.marshal") }.from(false).to(true)
+        }.to change{ File.exist?("./test.marshal") }.from(false).to(true)
       end
 
       it "records the tcp session data into the marshalled file" do


### PR DESCRIPTION
## Changes
Ruby 3.1, 3.2 were added to the matrix of the CI. 

Although the spec suite was already passing in Ruby 3.1, to add the support for Ruby 3.2 was necessary to replace with `exist?` the method `exists?` which was totally removed since Ruby 3.2.

## Extra comment
To continue having the Ruby 2.2 version in the CI, it was necessary to run it in other ubuntu version due to some problems while trying to install `bundler`.
Further information about this can be found here:

- https://github.com/ruby/setup-ruby/issues/496
- https://github.com/rubygems/rubygems.org/issues/3698